### PR TITLE
Allowed the save option to be changed without reloading

### DIFF
--- a/lib/git-wip.coffee
+++ b/lib/git-wip.coffee
@@ -24,10 +24,9 @@ module.exports = GitWip =
 
 
     # Register event listener for file saves
-    shouldWipOnSave = atom.config.get "#{@packageName}.wipOnSave"
-    if shouldWipOnSave
-      @subscriptions.add atom.workspace.observeTextEditors (editor) =>
-        editor.onDidSave (event) =>
+    @subscriptions.add atom.workspace.observeTextEditors (editor) =>
+      editor.onDidSave (event) =>
+        if atom.config.get "#{@packageName}.wipOnSave"
           @doGitWip(editor.getPath())
 
     # Register command that toggles this view


### PR DESCRIPTION
The save option was only read on activate, meaning that the package
had to be reloaded before the wipOnSave option was reapplied. Changed
the option to be read on every save so that it can be dynamically
toggled.
